### PR TITLE
minor bug fixes

### DIFF
--- a/configs/train/monorec/monorec_depth_ref.json
+++ b/configs/train/monorec/monorec_depth_ref.json
@@ -12,7 +12,7 @@
       "depth_cp_loc": [
         "saved/models/monorec_depth/00/checkpoint.pth"
       ],
-      "att_cp_loc": [
+      "mask_cp_loc": [
         "saved/models/monorec_mask_ref/00/checkpoint.pth"
       ],
       "freeze_module": [

--- a/data_loader/tum_mono_vo_dataset.py
+++ b/data_loader/tum_mono_vo_dataset.py
@@ -227,7 +227,7 @@ class TUMMonoVODataset(Dataset):
 
     def build_poses(self):
         ts = torch.tensor(self._result[:, 1:4])
-        qs = torch.tensor(self._result[:, [7, 4, 5, 6]])
+        qs = torch.tensor(self._result[:, 4:])
         rs = torch.eye(4).unsqueeze(0).repeat(qs.shape[0], 1, 1)
         rs[:, :3, :3] = torch.tensor(Rotation.from_quat(qs).as_matrix())
         rs[:, :3, 3] = ts * self.scale_factor

--- a/data_loader/tum_rgbd_dataset.py
+++ b/data_loader/tum_rgbd_dataset.py
@@ -117,7 +117,7 @@ class TUMRGBDDataset(Dataset):
         data = np.genfromtxt(lines, dtype=np.float64)
         times = data[:, 0]
         ts = torch.tensor(data[:, 1:4])
-        qs = torch.tensor(data[:, [7, 4, 5, 6]])
+        qs = torch.tensor(data[:, 4:])
         rs = torch.eye(4).unsqueeze(0).repeat(qs.shape[0], 1, 1)
         rs[:, :3, :3] = torch.tensor(Rotation.from_quat(qs).as_matrix())
         rs[:, :3, 3] = ts

--- a/utils/ply_utils.py
+++ b/utils/ply_utils.py
@@ -39,7 +39,7 @@ class PLYSaver(torch.nn.Module):
         if self.roi is not None:
             mask[:, :, :self.roi[0], :] = False
             mask[:, :, self.roi[1]:, :] = False
-            mask[:, :, :, self.roi[2]] = False
+            mask[:, :, :, :self.roi[2]] = False
             mask[:, :, :, self.roi[3]:] = False
         if self.dropout > 0:
             mask = mask & (torch.rand_like(depth) > self.dropout)


### PR DESCRIPTION
Following are the proposed changes:
[Fix 1](https://github.com/Brummi/MonoRec/commit/2d46273196306659f41ef3921727ece6d5791df1): Masking of the depth from a given roi had a mistake in the [ply_utils.py](https://github.com/Brummi/MonoRec/compare/main...hardik01shah:MonoRec:main#diff-712b0e42e4b8959dc0ae59ab6dfa355279062c21eb555f74604365a434886f12) file
[Fix 2](https://github.com/Brummi/MonoRec/commit/51bdbdc2c3c2f883563b594e60f837ee1c9e1d9e): Parameter for mask_module checkpoint location in the [config](https://github.com/Brummi/MonoRec/compare/main...hardik01shah:MonoRec:main#diff-5f94464bb01eeb4dfa96b881a24f613dfd757db4976604f3b6b3f3467efe6da5) file has been corrected from ```att_cp_loc``` to ```mask_cp_loc```.  
[Fix3](https://github.com/Brummi/MonoRec/commit/b3ec527a93517603c9a7f9e32a0d83117fb4c817): Conversion of pose from quaternion to rotation matrix in the [tum_mono](https://github.com/Brummi/MonoRec/compare/main...hardik01shah:MonoRec:main#diff-b86b6e85704171e274d52c9f8fe849259150431c27f239e3ee59ed612dbb04a0) and [tum_rgbd](https://github.com/Brummi/MonoRec/compare/main...hardik01shah:MonoRec:main#diff-c270e0c082c3f2ab47277560945807c1ede6f5b4cd1f58c187bb43528cff924c) dataloaders has been fixed. The [```scipy.spatial.transform.Rotation.from_quat()```](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.from_quat.html) method takes input in scalar-last format (qx, qy, qz, qw) rather than (qw, qx, qy, qz).